### PR TITLE
Run the job only for production environment

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,8 @@ app.use('/api/bot', botRouter)
 app.use('/config', configRouter)
 
 // Jobs
-slackJob.start()
+if (process.env.NODE_ENV === 'production') {
+  slackJob.start()
+}
 
 module.exports = app


### PR DESCRIPTION
### This PR will

* Change the way the slack bot job is started to only be working on production environments